### PR TITLE
Depend on c2hs

### DIFF
--- a/webkit-javascriptcore.cabal-renamed
+++ b/webkit-javascriptcore.cabal-renamed
@@ -31,7 +31,7 @@ custom-setup
 Library
         hs-source-dirs: src
         build-depends:  base >= 4 && < 5
-						
+        build-tools:    c2hs
         exposed-modules:
                    Graphics.UI.Gtk.WebKit.JavaScriptCore.JSBase
                    Graphics.UI.Gtk.WebKit.JavaScriptCore.JSContextRef

--- a/webkit2gtk3-javascriptcore.cabal
+++ b/webkit2gtk3-javascriptcore.cabal
@@ -31,6 +31,7 @@ custom-setup
 Library
         hs-source-dirs: src
         build-depends:  base >= 4 && < 5
+        build-tools:    c2hs
 
         exposed-modules:
                    Graphics.UI.Gtk.WebKit.JavaScriptCore.JSBase

--- a/webkitgtk3-javascriptcore.cabal-renamed
+++ b/webkitgtk3-javascriptcore.cabal-renamed
@@ -31,7 +31,7 @@ custom-setup
 Library
         hs-source-dirs: src
         build-depends:  base >= 4 && < 5
-						
+        build-tools:    c2hs
         exposed-modules:
                    Graphics.UI.Gtk.WebKit.JavaScriptCore.JSBase
                    Graphics.UI.Gtk.WebKit.JavaScriptCore.JSContextRef


### PR DESCRIPTION
I think that the lack of explicit dependency on `c2hs` is causing the following error:

```
Graphics/UI/Gtk/WebKit/JavaScriptCore/JSValueRef.chi not found
```

See also: https://logs.nix.samueldr.com/haskell.nix/2021-05-22